### PR TITLE
ci: fix for fork's repo

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,6 +1,6 @@
 name: check-pr-title
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
对于从 fork 的仓库中提交的 Pull Request
正如 https://github.com/e-dialect/hinghwa-dict-uni-app/actions/runs/2733553759 可以看到发生权限不足的问题
提升权限即可