### PR TITLE
feat: adapt video showing for wechat

### DIFF
--- a/src/utils/u-parse/components/IFramePlayer.vue
+++ b/src/utils/u-parse/components/IFramePlayer.vue
@@ -13,7 +13,7 @@
       </button>
     </view>
     <view v-else>
-      <button type="link" @tap="visible=true">点击查看视频</button>
+      <button type="link" @tap="onTap">点击查看视频</button>
     </view>
   </view>
 </template>
@@ -30,6 +30,31 @@ export default {
   data() {
     return {
       visible: false
+    }
+  },
+  methods:{
+    onTap(){
+      // #ifdef MP-WEIXIN
+      uni.setClipboardData({
+        data: this.src,
+        success: function () {
+          uni.showToast({
+            title: '已复制视频链接',
+          })
+        },
+        fail: function () {
+          uni.showToast({
+            title: '无法复制链接至剪切板，请手动复制',
+            icon: 'fail'
+          })
+          this.visible=true
+        }
+      });
+      // #endif
+      // #ifndef MP-WEIXIN
+      this.visible = true;
+      // #endif
+
     }
   }
 }


### PR DESCRIPTION
微信小程序里无法直接播放视频
也为方便后续审核，改为复制视频链接至剪切板

@zzy2695s 帮忙测试一下是否能在微信开发者工具里实现这一点，如果可以的话点击 approve